### PR TITLE
Take reserved space into account

### DIFF
--- a/disk_linux.go
+++ b/disk_linux.go
@@ -2,7 +2,9 @@
 
 package main
 
-import "syscall"
+import (
+	"syscall"
+)
 
 // Data amount constants
 const (
@@ -23,11 +25,17 @@ type DiskStatus struct {
 func DiskUsage(path string) (disk DiskStatus) {
 	fs := syscall.Statfs_t{}
 	err := syscall.Statfs(path, &fs)
+
 	if err != nil {
 		return
 	}
+
+	// calculate number of blocks that are reserved by the filesystem
+	fsReservedBlocks := fs.Bfree - fs.Bavail
+
 	disk.All = fs.Blocks * uint64(fs.Bsize)
-	disk.Free = fs.Bfree * uint64(fs.Bsize)
-	disk.Used = disk.All - disk.Free
+	disk.Free = fs.Bavail * uint64(fs.Bsize)
+	disk.Used = (fs.Blocks-fsReservedBlocks)*uint64(fs.Bsize) - disk.Free
+
 	return
 }

--- a/disk_macos.go
+++ b/disk_macos.go
@@ -26,8 +26,13 @@ func DiskUsage(path string) (disk DiskStatus) {
 	if err != nil {
 		return
 	}
+
+	// calculate number of blocks that are reserved by the filesystem
+	fsReservedBlocks := fs.Bfree - fs.Bavail
+
 	disk.All = fs.Blocks * uint64(fs.Bsize)
 	disk.Free = fs.Bavail * uint64(fs.Bsize)
-	disk.Used = disk.All - disk.Free
+	disk.Used = (fs.Blocks-fsReservedBlocks)*uint64(fs.Bsize) - disk.Free
+
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module diskMonitor
+module github.com/n0str/diskMonitor
 
 go 1.12
+
+require golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/n0str/diskMonitor
 
 go 1.12
-
-require golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
+github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
+github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/shirou/gopsutil v2.20.9+incompatible h1:msXs2frUV+O/JLva9EDLpuJ84PrFsdCTCQex8PUdtkQ=
+github.com/shirou/gopsutil v2.20.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac h1:bplbaOojU0hnrC9nvWJ5Nvp/gPIWKFMiGBFI9Cpp16I=
+golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,0 @@
-github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
-github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
-github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
-github.com/shirou/gopsutil v2.20.9+incompatible h1:msXs2frUV+O/JLva9EDLpuJ84PrFsdCTCQex8PUdtkQ=
-github.com/shirou/gopsutil v2.20.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac h1:bplbaOojU0hnrC9nvWJ5Nvp/gPIWKFMiGBFI9Cpp16I=
-golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -26,19 +26,20 @@ func Hostname() string {
 func main() {
 	flag.Parse()
 	disk := DiskUsage(*path)
+
+	percentUsed := 100 - 100*(float64(disk.Free)/float64(disk.All))
 	if *debug {
 		log.Printf("All: %.2f GB\n", float64(disk.All)/float64(GB))
 		log.Printf("Used: %.2f GB\n", float64(disk.Used)/float64(GB))
 		log.Printf("Free: %.2f GB\n", float64(disk.Free)/float64(GB))
-		log.Printf("Percent: %.0f%%\n", 100*(float64(disk.Used)/float64(disk.All)))
+		log.Printf("Percent: %.0f%%\n", percentUsed)
 	}
 
-	percentUsed := int(100 * (float64(disk.Used) / float64(disk.All)))
 	hostname := Hostname()
 
-	if percentUsed >= *alertLevel {
+	if int(percentUsed) >= *alertLevel {
 
-		alertMessage := fmt.Sprintf("🔥🚒 Running out of space `%.2fGB(%d%%)` on server %s", float64(disk.Free)/float64(GB), percentUsed, hostname)
+		alertMessage := fmt.Sprintf("🔥🚒 Running out of space `%.2fGB(%.0f%%)` on server %s", float64(disk.Free)/float64(GB), percentUsed, hostname)
 
 		// notify via CodeX Bot
 		if *codexBotURL != "" {


### PR DESCRIPTION
Now it looks more like `df -h` results
```
root@host:/tmp# df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/vda1        40G   37G  1.5G  97% /
udev             10M     0   10M   0% /dev
tmpfs           403M   41M  362M  11% /run
tmpfs          1006M   72K 1005M   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs          1006M     0 1006M   0% /sys/fs/cgroup
```

```
root@host:/tmp# ./diskMonitor-linux -debug
2020/10/29 10:57:19 All: 39.34 GB
2020/10/29 10:57:19 Used: 36.29 GB
2020/10/29 10:57:19 Free: 1.41 GB
2020/10/29 10:57:19 Percent: 96%
2020/10/29 10:57:19 🔥🚒 Running out of space `1.41GB(96%)` on server host
```